### PR TITLE
Extend moon illumination to include angle of illuminated limb

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ Returns an object with the following properties:
 ### Moon illumination
 
 ```javascript
-SunCalc.getMoonFraction(/*Date*/ timeAndDate)
+SunCalc.getMoonIllumination(/*Date*/ timeAndDate)
 ```
 
-Returns the illuminated fraction of the moon; varies from `0.0` (new moon) to `1.0` (full moon).
+Returns an object with the following properties:
+
+ * `fraction`: illuminated fraction of the moon; varies from `0.0` (new moon) to `1.0` (full moon)
+ * `angle`: midpoint angle in radians of the illuminated limb of the moon reckoned eastward from the north point of the disk

--- a/suncalc.js
+++ b/suncalc.js
@@ -230,10 +230,12 @@ SunCalc.getMoonPosition = function (date, lat, lng) {
 };
 
 
-// calculations for illuminated fraction of the moon,
-// based on http://idlastro.gsfc.nasa.gov/ftp/pro/astro/mphase.pro formulas
+// calculations for illumination parameters of the moon,
+// based on http://idlastro.gsfc.nasa.gov/ftp/pro/astro/mphase.pro formulas and
+// Chapter 48 of "Astronomical Algorithms" 2nd edition by Jean Meeus
+// (Willmann-Bell, Richmond) 1998.
 
-SunCalc.getMoonFraction = function (date) {
+SunCalc.getMoonIllumination = function (date) {
 
     var d = toDays(date),
         s = getSunCoords(d),
@@ -244,7 +246,11 @@ SunCalc.getMoonFraction = function (date) {
         phi = acos(sin(s.dec) * sin(m.dec) + cos(s.dec) * cos(m.dec) * cos(s.ra - m.ra)),
         inc = atan(sdist * sin(phi), m.dist - sdist * cos(phi));
 
-    return (1 + cos(inc)) / 2;
+    return {
+        fraction: (1 + cos(inc)) / 2,
+        angle: atan(cos(s.dec) * sin(s.ra - m.ra), sin(s.dec) * cos(m.dec)
+            - cos(s.dec) * sin(m.dec) * cos(s.ra - m.ra))
+    };
 };
 
 

--- a/test.js
+++ b/test.js
@@ -59,9 +59,12 @@ describe('SunCalc', function () {
         });
     });
 
-    describe('getMoonFraction', function () {
-        it('should return fraction of illuminated moon given time', function () {
-            assertNear(SunCalc.getMoonFraction(date), 0.4848068202456373);
+    describe('getMoonIllumination', function () {
+        it('should return an object with correct fraction and angle of moon\'s illuminated limb given time', function () {
+            var moonIllum = SunCalc.getMoonIllumination(date);
+
+            assertNear(moonIllum.fraction, 0.4848068202456373);
+            assertNear(moonIllum.angle, 1.6732942678578346);
         });
     });
 });


### PR DESCRIPTION
I extended the moon illumination calculations to also calculate the angle of the illuminated limb. The algorithm is from Chapter 48 of _Astronomical Algorithms_, 2nd edition by Jean Meeus.
