### PR TITLE
Generate suncalc.min.js.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+suncalc.min.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+NODE?=	node
+
+.PHONY : default build clean test
+default: build test
+
+build: suncalc.min.js
+
+clean:
+	rm -f *.min.js
+
+test: test.js suncalc.js
+	jshint $^
+	node "$<" | faucet
+
+%.min.js: %.js
+	uglifyjs "$<" --output "$@" --comments '/mourner\/suncalc/'  --lint

--- a/package.json
+++ b/package.json
@@ -19,14 +19,16 @@
     "type": "git",
     "url": "git://github.com/mourner/suncalc.git"
   },
-  "main": "suncalc.js",
+  "main": "suncalc.min.js",
   "devDependencies": {
     "tape": "^2.12.3",
     "jshint": "^2.5.0",
-    "faucet": "0.0.1"
+    "faucet": "0.0.1",
+    "uglify-js": ">=2.0.0"
   },
   "scripts": {
     "test": "jshint suncalc.js test.js && node test.js | faucet",
+    "build": "make build",
     "cov": "istanbul cover test.js -x test.js"
   },
   "jshintConfig": {


### PR DESCRIPTION
Background: As you probably know I use this library in [opening_hours.js](https://github.com/ypid/opening_hours.js) (which works great by the way). I currently write an the Android application [ComplexAlarm](https://github.com/ypid/ComplexAlarm) which depends on opening_hours.js and thus also on suncalc. To execute JS on Android I use [js-evaluator-for-android](https://github.com/evgenyneu/js-evaluator-for-android) which requires a minified file.
