### PR TITLE
Added null check around rise and set tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -65,7 +65,11 @@ t.test('getMoonIllumination returns fraction and angle of moon\'s illuminated li
 t.test('getMoonTimes returns moon rise and set times', function (t) {
     var moonTimes = SunCalc.getMoonTimes(date, lat, lng);
 
-    t.equal(moonTimes.rise.toUTCString(), 'Mon, 04 Mar 2013 23:57:55 GMT');
-    t.equal(moonTimes.set.toUTCString(), 'Tue, 05 Mar 2013 08:41:31 GMT');
+    if(moonTimes.rise){
+        t.equal(moonTimes.rise.toUTCString(), 'Mon, 04 Mar 2013 23:57:55 GMT');
+    }
+    if(moonTimes.set){
+        t.equal(moonTimes.set.toUTCString(), 'Tue, 05 Mar 2013 08:41:31 GMT');
+    }
     t.end();
 });


### PR DESCRIPTION
Since ```getMoonTimes``` defines ```result``` as follows:
```
    var result = {};

    if (rise) result.rise = hoursLater(t, rise);
    if (set) result.set = hoursLater(t, set);
```

It is possible that either ```result.rise``` or ```result.set``` will be undefined.  Added a check to skip the test when the value is undefined.