### PR TITLE
parallactic angle of the moon

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Returns an object with the following properties:
  * `altitude`: moon altitude above the horizon in radians
  * `azimuth`: moon azimuth in radians
  * `distance`: distance to moon in kilometers
+ * `parallacticAngle`: parallactic angle of the moon in radians
 
 
 ### Moon illumination
@@ -132,6 +133,9 @@ Moon phase value should be interpreted like this:
 |       | Waning Gibbous  |
 | 0.75  | Last Quarter    |
 |       | Waning Crescent |
+
+By subtracting the `parallacticAngle` from the `angle` one can get the zenith angle of the moons bright limb (anticlockwise).
+The zenith angle can be used do draw the moon shape from the observers perspective (e.g. moon lying on its back). 
 
 ### Moon rise and set times
 

--- a/suncalc.js
+++ b/suncalc.js
@@ -193,7 +193,9 @@ SunCalc.getMoonPosition = function (date, lat, lng) {
 
         c = moonCoords(d),
         H = siderealTime(d, lw) - c.ra,
-        h = altitude(H, phi, c.dec);
+        h = altitude(H, phi, c.dec),
+        // formula 14.1 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
+        pa = atan(sin(H), tan(phi) * cos(c.dec) - sin(c.dec) * cos(H));
 
     // altitude correction for refraction
     h = h + rad * 0.017 / tan(h + rad * 10.26 / (h + rad * 5.10));
@@ -201,7 +203,8 @@ SunCalc.getMoonPosition = function (date, lat, lng) {
     return {
         azimuth: azimuth(H, phi, c.dec),
         altitude: h,
-        distance: c.dist
+        distance: c.dist,
+        parallacticAngle: pa
     };
 };
 


### PR DESCRIPTION
I added the calculation of the parallactic angle to the moon position.
By subtracting the parallactic angle from the illumination angle one can get the zenith angle of the moons bright limb (anticlockwise).
The zenith angle can be used do draw the moon shape from the observers perspective (e.g. moon lying on its back). 