### PR TITLE
fixed bug on calculation of astronomical refraction

### DIFF
--- a/suncalc.js
+++ b/suncalc.js
@@ -43,6 +43,14 @@ function altitude(H, phi, dec) { return asin(sin(phi) * sin(dec) + cos(phi) * co
 
 function siderealTime(d, lw) { return rad * (280.16 + 360.9856235 * d) - lw; }
 
+function astroRefraction(h) {         
+    if (h < 0) // the following formula works for positive altitudes only.
+        h = 0; // if h = -0.08901179 a div/0 would occur. 
+
+    // formula 16.4 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
+    // 1.02 / tan(h + 10.26 / (h + 5.10)) h in degrees, result in arc minutes -> converted to rad: 
+    return 0.0002967  / Math.tan(h + 0.00312536 / (h + 0.08901179));
+}
 
 // general sun calculations
 
@@ -197,9 +205,8 @@ SunCalc.getMoonPosition = function (date, lat, lng) {
         // formula 14.1 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
         pa = atan(sin(H), tan(phi) * cos(c.dec) - sin(c.dec) * cos(H));
 
-    // altitude correction for refraction
-    h = h + rad * 0.017 / tan(h + rad * 10.26 / (h + rad * 5.10));
-
+    h = h + astroRefraction(h); // altitude correction for refraction
+	
     return {
         azimuth: azimuth(H, phi, c.dec),
         altitude: h,

--- a/suncalc.js
+++ b/suncalc.js
@@ -43,12 +43,12 @@ function altitude(H, phi, dec) { return asin(sin(phi) * sin(dec) + cos(phi) * co
 
 function siderealTime(d, lw) { return rad * (280.16 + 360.9856235 * d) - lw; }
 
-function astroRefraction(h) {         
+function astroRefraction(h) {
     if (h < 0) // the following formula works for positive altitudes only.
-        h = 0; // if h = -0.08901179 a div/0 would occur. 
+        h = 0; // if h = -0.08901179 a div/0 would occur.
 
     // formula 16.4 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
-    // 1.02 / tan(h + 10.26 / (h + 5.10)) h in degrees, result in arc minutes -> converted to rad: 
+    // 1.02 / tan(h + 10.26 / (h + 5.10)) h in degrees, result in arc minutes -> converted to rad:
     return 0.0002967  / Math.tan(h + 0.00312536 / (h + 0.08901179));
 }
 
@@ -206,7 +206,7 @@ SunCalc.getMoonPosition = function (date, lat, lng) {
         pa = atan(sin(H), tan(phi) * cos(c.dec) - sin(c.dec) * cos(H));
 
     h = h + astroRefraction(h); // altitude correction for refraction
-	
+
     return {
         azimuth: azimuth(H, phi, c.dec),
         altitude: h,


### PR DESCRIPTION
the formula 16.4 of "Astronomical Algorithms" 2nd edition is now translated correctly to radians.
the new calculation leads to the expected values of https://en.wikipedia.org/wiki/Atmospheric_refraction. 

additionally the calculation works also for negative altitudes now. 
negative altitudes of a few degrees may occur if the observer is standing on a high mountain.  

