### PR TITLE
Try to export as Node module first

### DIFF
--- a/suncalc.js
+++ b/suncalc.js
@@ -302,9 +302,9 @@ SunCalc.getMoonTimes = function (date, lat, lng, inUTC) {
 };
 
 
-// export as AMD module / Node module / browser variable
-if (typeof define === 'function' && define.amd) define(SunCalc);
-else if (typeof module !== 'undefined') module.exports = SunCalc;
+// export as Node module / AMD module / browser variable
+if (typeof exports === 'object' && typeof module !== 'undefined') module.exports = SunCalc;
+else if (typeof define === 'function' && define.amd) define(SunCalc);
 else window.SunCalc = SunCalc;
 
 }());


### PR DESCRIPTION
When loading SunCalc with browserify or webpack, if a global AMD loader
is defined on the same page, require('suncalc') returned an empty object.