### PR TITLE
Add test for variety of date/time stamps

### DIFF
--- a/test.js
+++ b/test.js
@@ -80,7 +80,7 @@ t.test('getTimes day detection works with a variety of date times', function (t)
         'Mon, 04 Mar 2013 12:00:00 PDT',
         'Mon, 04 Mar 2013 23:59:59 PDT'
     ];
-    for (var i = 0, l = dateStrings.length; i < l; i++) {
+    for (var i = 0, l = testDateStrings.length; i < l; i++) {
         var times = SunCalc.getTimes(new Date(testDateStrings[i]), lat, lng);
         t.equal(times.solarNoon.getDate(), testDateDay, testDateStrings[i]);
     }

--- a/test.js
+++ b/test.js
@@ -72,18 +72,16 @@ t.test('getMoonTimes returns moon rise and set times', function (t) {
 });
 
 t.test('getTimes day detection works with a variety of date times', function (t) {
-    var latitude = 47.606209;
-    var longitude = -122.332069;
-    var targetDay = 4;
-    var dateStrings = [
+    var lat = 47.606209;
+    var lng = -122.332069;
+    var testDateDay = 4;
+    var testDateStrings = [
         'Mon, 04 Mar 2013 00:00:01 PDT',
         'Mon, 04 Mar 2013 12:00:00 PDT',
         'Mon, 04 Mar 2013 23:59:59 PDT'
     ];
     for (var i = 0, l = dateStrings.length; i < l; i++) {
-        var dateString = dateStrings[i];
-        var date = new Date(dateString);
-        var times = SunCalc.getTimes(date, latitude, longitude);
-        t.equal(times.solarNoon.getDate(), targetDay, dateString);
+        var times = SunCalc.getTimes(new Date(testDateStrings[i]), lat, lng);
+        t.equal(times.solarNoon.getDate(), testDateDay, testDateStrings[i]);
     }
 });

--- a/test.js
+++ b/test.js
@@ -70,3 +70,20 @@ t.test('getMoonTimes returns moon rise and set times', function (t) {
 
     t.end();
 });
+
+t.test('getTimes day detection works with a variety of date times', function (t) {
+    var latitude = 47.606209;
+    var longitude = -122.332069;
+    var targetDay = 4;
+    var dateStrings = [
+        'Mon, 04 Mar 2013 00:00:01 PDT',
+        'Mon, 04 Mar 2013 12:00:00 PDT',
+        'Mon, 04 Mar 2013 23:59:59 PDT'
+    ];
+    for (var i = 0, l = dateStrings.length; i < l; i++) {
+        var dateString = dateStrings[i];
+        var date = new Date(dateString);
+        var times = SunCalc.getTimes(date, latitude, longitude);
+        t.equal(times.solarNoon.getDate(), targetDay, dateString);
+    }
+});


### PR DESCRIPTION
When using this library in Seattle, WA, USA it was found that date objects with a small time (ex: 00:01:00) would be interpreted by the library as occurring the day before.

This test exposes the problem, but unfortunately it doesn't offer a solution (guessing the issue is with `toJulian()` and `toDays()`?)